### PR TITLE
ci: Fix submit workflow

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -55,6 +55,7 @@ jobs:
         with:
           path: .output/*.zip
           if-no-files-found: error
+          include-hidden-files: true
 
       - name: Submit
         run: |
@@ -88,4 +89,6 @@ jobs:
 
       - name: Release
         if: ${{ !inputs.dryRun }}
-        run: pnpx changelogen@latest gh release ${{ steps.version.outputs.newVersion }} --token ${{ github.token }}
+        run: gh release create v${{ steps.version.outputs.newVersion }} .output/*.zip -F CHANGELOG.md
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -89,6 +89,9 @@ jobs:
 
       - name: Release
         if: ${{ !inputs.dryRun }}
-        run: gh release create v${{ steps.version.outputs.newVersion }} .output/*.zip -F CHANGELOG.md
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: pnpx changelogen@latest gh release ${{ steps.version.outputs.newVersion }} --token ${{ github.token }}
+
+      # Don't upload sources zip - it can contain .env files, which may include secrets
+      - name: Upload ZIPs
+        if: ${{ !inputs.dryRun }}
+        run: gh release upload ${{ steps.version.outputs.newVersion }} .output/*-chrome.zip .output/*-firefox.zip


### PR DESCRIPTION
Hi! I was using your workflow as an example and ran into some issues.

1. Include hidden files, because `.output` listed in `.gitignore`
1. `gh` command didn't work for me. 
   1. Not really sure why we should run `changelogen` again if we have CHANGELOG.md, just pass it to `gh`  command.
   1. We can specify token in `env`.
   1. Include assets